### PR TITLE
Fix stubs for 6.7.0

### DIFF
--- a/remove-duplicates.php
+++ b/remove-duplicates.php
@@ -37,10 +37,6 @@ function remove_duplicates_and_fix() {
 		'@tad_DI52_ServiceProvider@' => [ // class alias, see `vendor/the-events-calendar/the-events-calendar/common/src/functions/aliases.php`.
 			'replacement' => 'TEC\Common\lucatume\DI52\ServiceProvider',
 		],
-		'@^(\s+)(class Events_Result_Set )@m' => [
-			'replacement' => '$1#[\ReturnTypeWillChange]' . \PHP_EOL . '$1$2',
-			'count'       => 1,
-		],
 	];
 	$replaced  = false;
 

--- a/remove-duplicates.php
+++ b/remove-duplicates.php
@@ -27,6 +27,7 @@ function remove_duplicates_and_fix() {
 		return;
 	}
 
+	$aliases_contents = str_replace( 'class_alias( $class, $alias );', 'class_alias( $class, $alias, false );', $aliases_contents );
 	$aliases_contents = preg_replace(
 		'/^<\?php\n/s',
 		"<?php\n\nnamespace {",

--- a/remove-duplicates.php
+++ b/remove-duplicates.php
@@ -27,6 +27,12 @@ function remove_duplicates_and_fix() {
 		return;
 	}
 
+	$aliases_contents = preg_replace(
+		'/^<\?php\n/s',
+		"<?php\n\nnamespace {",
+		$aliases_contents,
+		1
+	) . "\n}";
 	$contents = preg_replace( '/^<\?php/', $aliases_contents, $contents, 1 );
 
 	$to_remove = [

--- a/the-events-calendar-stubs.php
+++ b/the-events-calendar-stubs.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace {
 /**
  * Registers the library aliases redirecting calls to the `tad_DI52_`, non-namespaced, class format to the namespaced
  * classes.
@@ -14,6 +15,7 @@ foreach ( $aliases as [$class, $alias] ) {
 	if ( ! class_exists( $alias ) ) {
 		class_alias( $class, $alias );
 	}
+}
 }
 
 namespace TEC\Common\Admin\Entities {

--- a/the-events-calendar-stubs.php
+++ b/the-events-calendar-stubs.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Registers the library aliases redirecting calls to the `tad_DI52_`, non-namespaced, class format to the namespaced
+ * classes.
+ */
+
+$aliases = [
+	[ 'TEC\Common\lucatume\DI52\Container', 'tad_DI52_Container' ],
+	[ 'TEC\Common\lucatume\DI52\ServiceProvider', 'tad_DI52_ServiceProvider' ]
+];
+
+foreach ( $aliases as [$class, $alias] ) {
+	if ( ! class_exists( $alias ) ) {
+		class_alias( $class, $alias );
+	}
+}
+
 namespace TEC\Common\Admin\Entities {
     /**
      * Interface Element

--- a/the-events-calendar-stubs.php
+++ b/the-events-calendar-stubs.php
@@ -93129,7 +93129,6 @@ namespace Tribe\Events\Views\V2\Repository {
      *
      * @package Tribe\Events\Views\V2\Repository
      */
-    #[\ReturnTypeWillChange]
     class Events_Result_Set implements \Tribe\Utils\Collection_Interface
     {
         use \Tribe\Utils\Collection_Trait;

--- a/the-events-calendar-stubs.php
+++ b/the-events-calendar-stubs.php
@@ -1,23 +1,5 @@
 <?php
 
-namespace {
-/**
- * Registers the library aliases redirecting calls to the `tad_DI52_`, non-namespaced, class format to the namespaced
- * classes.
- */
-
-$aliases = [
-	[ 'TEC\Common\lucatume\DI52\Container', 'tad_DI52_Container' ],
-	[ 'TEC\Common\lucatume\DI52\ServiceProvider', 'tad_DI52_ServiceProvider' ]
-];
-
-foreach ( $aliases as [$class, $alias] ) {
-	if ( ! class_exists( $alias ) ) {
-		class_alias( $class, $alias, false );
-	}
-}
-}
-
 namespace TEC\Common\Admin\Entities {
     /**
      * Interface Element
@@ -4410,7 +4392,7 @@ namespace TEC\Event_Automator {
      *
      * @package TEC\Event_Automator
      */
-    class Plugin extends \tad_DI52_ServiceProvider
+    class Plugin extends \TEC\Common\lucatume\DI52\ServiceProvider
     {
         /**
          * Stores the version for the plugin.
@@ -4470,9 +4452,9 @@ namespace TEC\Event_Automator {
          *
          * @since 6.0.0
          *
-         * @param \tad_DI52_Container $container The container to use.
+         * @param \TEC\Common\lucatume\DI52\Container $container The container to use.
          */
-        public function __construct(\tad_DI52_Container $container)
+        public function __construct(\TEC\Common\lucatume\DI52\Container $container)
         {
         }
         /**
@@ -93147,6 +93129,7 @@ namespace Tribe\Events\Views\V2\Repository {
      *
      * @package Tribe\Events\Views\V2\Repository
      */
+    #[\ReturnTypeWillChange]
     class Events_Result_Set implements \Tribe\Utils\Collection_Interface
     {
         use \Tribe\Utils\Collection_Trait;

--- a/the-events-calendar-stubs.php
+++ b/the-events-calendar-stubs.php
@@ -13,7 +13,7 @@ $aliases = [
 
 foreach ( $aliases as [$class, $alias] ) {
 	if ( ! class_exists( $alias ) ) {
-		class_alias( $class, $alias );
+		class_alias( $class, $alias, false );
 	}
 }
 }


### PR DESCRIPTION
Because of class aliases defined in `vendor/the-events-calendar/the-events-calendar/common/src/functions/aliases.php`, the stubs trigger a fatal error:
```
Error thrown in /polylang-pro/vendor/wpsyntex/the-events-calendar-stubs/the-events-calendar-stubs.php on line 4395 while loading bootstrap file /polylang-pro/vendor/wpsyntex/the-events-calendar-stubs/the-events-calendar-stubs.php: Class "tad_DI52_ServiceProvider" not found
```

This is because 2 classes extend the aliases instead of the real class names.

Unfortunately I couldn't find any solution by including the file `aliases.php` directly into the stubs: this solution always throws a warning about the original classes not being defined, even by setting the autoloader parameter from `class_alias()` to `false`.

So I chose to directly replace the aliased named by the real class names in the stubs.